### PR TITLE
Fix clearing stored config on restore

### DIFF
--- a/firmware/AVR-Source/Pyr0_Piezo_Sensor_v2.x.x/src/pP_config.cpp
+++ b/firmware/AVR-Source/Pyr0_Piezo_Sensor_v2.x.x/src/pP_config.cpp
@@ -69,7 +69,7 @@ void restoreConfig() {
     }
 
     long longTemp;
-    EEPROM.get(VM_CONST_DEFAULT, longTemp);
+    EEPROM.get(VM_CONST_ADDRESS, longTemp);
     if (longTemp < 1000000L || longTemp > 1200000L) {
         resetEEPROM();
     } else {

--- a/firmware/AVR-Source/Pyr0_Piezo_Sensor_v2.x.x/src/pP_function.h
+++ b/firmware/AVR-Source/Pyr0_Piezo_Sensor_v2.x.x/src/pP_function.h
@@ -71,7 +71,7 @@ update the voltMeterConstant variable in pP_config.h with the correct value
 
  void readVin() {
    VOld = Vin;
-	 Vin = readVcc(), DEC;
+	 Vin = readVcc();
    followerLong = followerThrs * 1023L;
    compLong = compThrs * 1023L;
    followerInt = (long long) followerLong / Vin;


### PR DESCRIPTION
Looks like it was picking up the default value for VM_CONST instead of the address.  This caused it to read from the actual address on restore, and fail to find a value inside of its acceptable range, causing a complete config wipe.

Good idea on checking the read values!  Prevents potentially damaging something, for sure.